### PR TITLE
[Feat] #5 - UserInfoSignUpViewModel 의 로직 Unit Test 코드 구현

### DIFF
--- a/Studing/Studing.xcodeproj/project.pbxproj
+++ b/Studing/Studing.xcodeproj/project.pbxproj
@@ -36,8 +36,19 @@
 		3F3CFDC02C98093700DC9F9A /* UniversityInfoViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F3CFDBF2C98093700DC9F9A /* UniversityInfoViewModel.swift */; };
 		3F3CFDC22C980B0E00DC9F9A /* UserInfoSignUpViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F3CFDC12C980B0E00DC9F9A /* UserInfoSignUpViewModel.swift */; };
 		3F3CFDC42C9815EB00DC9F9A /* UIViewController+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F3CFDC32C9815EB00DC9F9A /* UIViewController+.swift */; };
+		3F3CFDCC2C9827D200DC9F9A /* UserInfoSignUpViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F3CFDCB2C9827D200DC9F9A /* UserInfoSignUpViewModelTests.swift */; };
 		3FDEE9E32C970A7A00633C93 /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 3FDEE9E22C970A7A00633C93 /* SnapKit */; settings = {ATTRIBUTES = (Required, ); }; };
 /* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		3F3CFDCD2C9827D200DC9F9A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 3F39924D2C82C8E40045CF1E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 3F3992542C82C8E40045CF1E;
+			remoteInfo = Studing;
+		};
+/* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
 		3F25A3582C96A676006E2715 /* UIView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+.swift"; sourceTree = "<group>"; };
@@ -68,6 +79,8 @@
 		3F3CFDBF2C98093700DC9F9A /* UniversityInfoViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UniversityInfoViewModel.swift; sourceTree = "<group>"; };
 		3F3CFDC12C980B0E00DC9F9A /* UserInfoSignUpViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInfoSignUpViewModel.swift; sourceTree = "<group>"; };
 		3F3CFDC32C9815EB00DC9F9A /* UIViewController+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+.swift"; sourceTree = "<group>"; };
+		3F3CFDC92C9827D200DC9F9A /* StudingTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = StudingTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		3F3CFDCB2C9827D200DC9F9A /* UserInfoSignUpViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInfoSignUpViewModelTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -79,6 +92,13 @@
 				3FDEE9E32C970A7A00633C93 /* SnapKit in Frameworks */,
 				3F3992792C82C9FA0045CF1E /* FirebaseMessaging in Frameworks */,
 				3F3992762C82C9690045CF1E /* Moya in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3F3CFDC62C9827D200DC9F9A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -159,6 +179,7 @@
 			isa = PBXGroup;
 			children = (
 				3F3992572C82C8E40045CF1E /* Studing */,
+				3F3CFDCA2C9827D200DC9F9A /* StudingTests */,
 				3F3992562C82C8E40045CF1E /* Products */,
 				3FDEE9E12C970A7A00633C93 /* Frameworks */,
 			);
@@ -168,6 +189,7 @@
 			isa = PBXGroup;
 			children = (
 				3F3992552C82C8E40045CF1E /* Studing.app */,
+				3F3CFDC92C9827D200DC9F9A /* StudingTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -256,6 +278,14 @@
 			path = Model;
 			sourceTree = "<group>";
 		};
+		3F3CFDCA2C9827D200DC9F9A /* StudingTests */ = {
+			isa = PBXGroup;
+			children = (
+				3F3CFDCB2C9827D200DC9F9A /* UserInfoSignUpViewModelTests.swift */,
+			);
+			path = StudingTests;
+			sourceTree = "<group>";
+		};
 		3FDEE9E12C970A7A00633C93 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
@@ -289,6 +319,24 @@
 			productReference = 3F3992552C82C8E40045CF1E /* Studing.app */;
 			productType = "com.apple.product-type.application";
 		};
+		3F3CFDC82C9827D200DC9F9A /* StudingTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 3F3CFDD12C9827D200DC9F9A /* Build configuration list for PBXNativeTarget "StudingTests" */;
+			buildPhases = (
+				3F3CFDC52C9827D200DC9F9A /* Sources */,
+				3F3CFDC62C9827D200DC9F9A /* Frameworks */,
+				3F3CFDC72C9827D200DC9F9A /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				3F3CFDCE2C9827D200DC9F9A /* PBXTargetDependency */,
+			);
+			name = StudingTests;
+			productName = StudingTests;
+			productReference = 3F3CFDC92C9827D200DC9F9A /* StudingTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -301,6 +349,10 @@
 				TargetAttributes = {
 					3F3992542C82C8E40045CF1E = {
 						CreatedOnToolsVersion = 15.3;
+					};
+					3F3CFDC82C9827D200DC9F9A = {
+						CreatedOnToolsVersion = 15.3;
+						TestTargetID = 3F3992542C82C8E40045CF1E;
 					};
 				};
 			};
@@ -324,6 +376,7 @@
 			projectRoot = "";
 			targets = (
 				3F3992542C82C8E40045CF1E /* Studing */,
+				3F3CFDC82C9827D200DC9F9A /* StudingTests */,
 			);
 		};
 /* End PBXProject section */
@@ -335,6 +388,13 @@
 			files = (
 				3F3992622C82C8E60045CF1E /* Assets.xcassets in Resources */,
 				3F3992652C82C8E60045CF1E /* Base in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3F3CFDC72C9827D200DC9F9A /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -372,7 +432,23 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		3F3CFDC52C9827D200DC9F9A /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3F3CFDCC2C9827D200DC9F9A /* UserInfoSignUpViewModelTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		3F3CFDCE2C9827D200DC9F9A /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 3F3992542C82C8E40045CF1E /* Studing */;
+			targetProxy = 3F3CFDCD2C9827D200DC9F9A /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
 		3F3992632C82C8E60045CF1E /* LaunchScreen.storyboard */ = {
@@ -561,6 +637,44 @@
 			};
 			name = Release;
 		};
+		3F3CFDCF2C9827D200DC9F9A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = N3H27N59VG;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "Studing/Global/Supporting Files/Info.plist";
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.Niro.StudingTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Studing.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Studing";
+			};
+			name = Debug;
+		};
+		3F3CFDD02C9827D200DC9F9A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = N3H27N59VG;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "Studing/Global/Supporting Files/Info.plist";
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.Niro.StudingTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Studing.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Studing";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -578,6 +692,15 @@
 			buildConfigurations = (
 				3F39926A2C82C8E60045CF1E /* Debug */,
 				3F39926B2C82C8E60045CF1E /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		3F3CFDD12C9827D200DC9F9A /* Build configuration list for PBXNativeTarget "StudingTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				3F3CFDCF2C9827D200DC9F9A /* Debug */,
+				3F3CFDD02C9827D200DC9F9A /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Studing/Studing/Present/Login & Signup/ViewController/UserInfoSignUpViewController.swift
+++ b/Studing/Studing/Present/Login & Signup/ViewController/UserInfoSignUpViewController.swift
@@ -79,7 +79,7 @@ private extension UserInfoSignUpViewController {
         let input = UserInfoSignUpViewModel.Input(
             userId: userIdTitleTextField.textPublisher.eraseToAnyPublisher(),
             userPw: userPwTextField.textPublisher.eraseToAnyPublisher(),
-            confirmPw: userPwTextField.textPublisher.eraseToAnyPublisher(),
+            confirmPw: comfirmPwTitleTextField.textPublisher.eraseToAnyPublisher(),
             nextTap: nextButton.tapPublisher)
         
         let output = viewModel.transform(input: input)
@@ -87,6 +87,13 @@ private extension UserInfoSignUpViewController {
         /// 다음 버튼이 눌릴 수 있는지
         output.isNextButtonEnabled
             .assign(to: \.isEnabled, on: nextButton)
+            .store(in: &cancellables)
+        
+        /// 비밀번호가 일치한지
+        output.isPasswordMatching
+            .sink { [weak self] isMatching in
+                print(isMatching ? "true" : "false")
+            }
             .store(in: &cancellables)
         
         /// UniversityInfoView 로 화면 전환

--- a/Studing/StudingTests/UserInfoSignUpViewModelTests.swift
+++ b/Studing/StudingTests/UserInfoSignUpViewModelTests.swift
@@ -1,0 +1,116 @@
+//
+//  UserInfoSignUpViewModelTests.swift
+//  StudingTests
+//
+//  Created by ParkJunHyuk on 9/16/24.
+//
+
+import XCTest
+import Combine
+@testable import Studing
+
+final class UserInfoSignUpViewModelTests: XCTestCase {
+
+    var viewModel: UserInfoSignUpViewModel!
+    var cancellables: Set<AnyCancellable>!
+    
+    var userIdSubject: PassthroughSubject<String, Never>!
+    var userPwSubject: PassthroughSubject<String, Never>!
+    var confirmPwSubject: PassthroughSubject<String, Never>!
+    var nextTapSubject: PassthroughSubject<Void, Never>!
+    
+    var input: UserInfoSignUpViewModel.Input!
+    var output: UserInfoSignUpViewModel.Output!
+    
+    override func setUp() {
+        super.setUp()
+        viewModel = UserInfoSignUpViewModel()
+        cancellables = []
+        
+        userIdSubject = PassthroughSubject<String, Never>()
+        userPwSubject = PassthroughSubject<String, Never>()
+        confirmPwSubject = PassthroughSubject<String, Never>()
+        nextTapSubject = PassthroughSubject<Void, Never>()
+        
+        // Input 초기화
+        input = UserInfoSignUpViewModel.Input(
+            userId: userIdSubject.eraseToAnyPublisher(),
+            userPw: userPwSubject.eraseToAnyPublisher(),
+            confirmPw: confirmPwSubject.eraseToAnyPublisher(),
+            nextTap: nextTapSubject.eraseToAnyPublisher()
+        )
+        
+        // Output 초기화
+        output = viewModel.transform(input: input)
+    }
+    
+    override func tearDown() {
+        viewModel = nil
+        cancellables = nil
+        super.tearDown()
+    }
+}
+
+extension UserInfoSignUpViewModelTests {
+    
+    /// 입력한 pw 와 확인하기 위한 pw 가 서로 일치하는지
+    func testIsPasswordMatching() {
+        
+        var isPasswordMatching: Bool = false
+        
+        output.isPasswordMatching
+            .sink { isMatching in
+                isPasswordMatching = isMatching
+            }.store(in: &cancellables)
+        
+        // 초기 상태: 비밀번호 필드가 비어있음
+        XCTAssertEqual(isPasswordMatching, false)
+        
+        // 비밀번호만 입력
+        userPwSubject.send("123456")
+        XCTAssertEqual(isPasswordMatching, false)
+        
+        // 비밀번호와 확인이 일치
+        confirmPwSubject.send("123456")
+        XCTAssertEqual(isPasswordMatching, true)
+        
+        // 비밀번호와 확인이 불일치
+        confirmPwSubject.send("123455")
+        XCTAssertEqual(isPasswordMatching, false)
+    }
+    
+    /// 유저 id, pw 를 입력하고
+    func testIsNextButtonEnabled() {
+        
+        var isNextButtonEnabled: Bool?
+        
+        output.isNextButtonEnabled
+            .sink { isEnabled in
+                isNextButtonEnabled = isEnabled
+            }
+            .store(in: &cancellables)
+        
+        // 초기 상태: 모든 필드가 비어있음
+        XCTAssertEqual(isNextButtonEnabled, false)
+        
+        // userId만 입력
+        userIdSubject.send("testUserId")
+        XCTAssertEqual(isNextButtonEnabled, false)
+        
+        // userId와 userPw 입력
+        userPwSubject.send("testPassword")
+        XCTAssertEqual(isNextButtonEnabled, false)
+        
+        // userId, userPw, confirmPw 입력 (일치)
+        confirmPwSubject.send("testPassword")
+        XCTAssertEqual(isNextButtonEnabled, true)
+        
+        // confirmPw를 불일치하게 변경
+        confirmPwSubject.send("wrongPassword")
+        XCTAssertEqual(isNextButtonEnabled, false)
+        
+        // 다시 모든 조건 충족
+        confirmPwSubject.send("testPassword")
+        XCTAssertEqual(isNextButtonEnabled, true)
+    }
+}


### PR DESCRIPTION
## 📟 관련 이슈
- Resolved: #5 

<br>

## 👷 작업한 내용
<!-- 작업한 내용을 적어주세요. -->
- UserInfoSignUpViewModel 의 로직을 테스트하기 위해 Unit Test 코드를 구현
- 비밀번호와 확인용 비밀번호가 일치하는지 테스트하는 `testIsPasswordMatching` 구현
- 유저 ID, 비밀번호, 확인용 비밀번호가 모두 입력됐고 일치하는지 테스트하는 `testIsNextButtonEnabled` 구현

<br>

## 📸 스크린샷
|기능|테스트 결과|
|:--:|:--:|
|IMG|<img src = "https://github.com/user-attachments/assets/0f6d5873-5ecb-40d9-9651-909362ff4b01" width ="700">|

총 2개의 테스트 (testIsNextButtonEnabled, testIsPasswordMatching) 를 실행했으며 
첫번째 테스트는 0.002초, 두번째 테스트는 0.000초만에 성공적으로 통과했다는 결과 값입니다.

<br>

## 🚨 참고 사항
<!-- 참고 사항을 적어주세요. 없으면 지워주세요. -->

Unit Test 코드를 처음 작성을 하다보니 어디까지 테스트가 가능한지, 어떤 것을 테스트 해야할지 막막했습니다.
많은 분들께서 추천하셨던건 가장 작은 단위 부터 테스트를 차근 차근 작성하면 갈수록 더 범위가 넓어지는 테스트까지 할 수 있다고 합니다.

결과적으로 이번에 작성한 `UserInfoSignUpViewModel` 의 로직을 테스트 하고자 하였고 해당 로직을 선정했습니다.

- 유저가 입력한 비밀번호와 확인용 비밀번호의 값이 일치한지?
- 유저가 입력한 아이디, 비밀번호, 확인용 비밀번호 의 값이 nil 이 아니고 비밀번호의 값이 같은지?

이렇게 선정한 테스트에는 여러 상황을 만들어야하는 경우의 수를 만들어야 하기 때문에 다음과 같이 성공, 실패 사례를 만들었습니다.

``` swift
/// 입력한 pw 와 확인하기 위한 pw 가 서로 일치하는지
func testIsPasswordMatching() {
    
    var isPasswordMatching: Bool = false
    
    output.isPasswordMatching
        .sink { isMatching in
            isPasswordMatching = isMatching
        }.store(in: &cancellables)
    
    // 초기 상태: 비밀번호 필드가 비어있음
    XCTAssertEqual(isPasswordMatching, false)
    
    // 비밀번호만 입력
    userPwSubject.send("123456")
    XCTAssertEqual(isPasswordMatching, false)
    
    // 비밀번호와 확인이 일치
    confirmPwSubject.send("123456")
    XCTAssertEqual(isPasswordMatching, true)
    
    // 비밀번호와 확인이 불일치
    confirmPwSubject.send("123455")
    XCTAssertEqual(isPasswordMatching, false)
}
```

작은 단위 테스트 부터 시작하여 나중에는 UI 테스트, 로직 테스트까지 진행할 수 있도록 경험을 쌓고자합니다!
또한 Xcod Cloud 나 Fastlane 을 사용해서 CI / CD 를 설정하고 테스트 로직도 진행할 수 있도록 하고자 합니다.

<br>

## ✅ Checklist
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
