### PR TITLE
[Feat] #11 - 회원가입 관련 Custom NavigationBar 구현

### DIFF
--- a/Studing/Studing.xcodeproj/project.pbxproj
+++ b/Studing/Studing.xcodeproj/project.pbxproj
@@ -14,6 +14,9 @@
 		3F162B8B2C9DAACC00DF2E1C /* Inter-VariableFont_opsz,wght.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 3F162B8A2C9DAACC00DF2E1C /* Inter-VariableFont_opsz,wght.ttf */; };
 		3F162B8D2C9DBA0D00DF2E1C /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 3F162B8C2C9DBA0D00DF2E1C /* LaunchScreen.storyboard */; };
 		3F1F1F782CA27720006DFD76 /* StepCountView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F1F1F772CA27720006DFD76 /* StepCountView.swift */; };
+		3F1F1F7C2CA3B859006DFD76 /* CusomSignUpNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F1F1F7B2CA3B858006DFD76 /* CusomSignUpNavigationController.swift */; };
+		3F1F1F7E2CA3D902006DFD76 /* SizeLiterals.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F1F1F7D2CA3D902006DFD76 /* SizeLiterals.swift */; };
+		3F1F1F802CA3F4CF006DFD76 /* MajorInfoViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F1F1F7F2CA3F4CF006DFD76 /* MajorInfoViewModel.swift */; };
 		3F25A3592C96A676006E2715 /* UIView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F25A3582C96A676006E2715 /* UIView+.swift */; };
 		3F25A35C2C96A76E006E2715 /* StringLiterals.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F25A35B2C96A76E006E2715 /* StringLiterals.swift */; };
 		3F25A35F2C96A85E006E2715 /* TitleTextFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F25A35E2C96A85E006E2715 /* TitleTextFieldView.swift */; };
@@ -67,6 +70,9 @@
 		3F162B8A2C9DAACC00DF2E1C /* Inter-VariableFont_opsz,wght.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Inter-VariableFont_opsz,wght.ttf"; sourceTree = "<group>"; };
 		3F162B8C2C9DBA0D00DF2E1C /* LaunchScreen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
 		3F1F1F772CA27720006DFD76 /* StepCountView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StepCountView.swift; sourceTree = "<group>"; };
+		3F1F1F7B2CA3B858006DFD76 /* CusomSignUpNavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CusomSignUpNavigationController.swift; sourceTree = "<group>"; };
+		3F1F1F7D2CA3D902006DFD76 /* SizeLiterals.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SizeLiterals.swift; sourceTree = "<group>"; };
+		3F1F1F7F2CA3F4CF006DFD76 /* MajorInfoViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MajorInfoViewModel.swift; sourceTree = "<group>"; };
 		3F25A3582C96A676006E2715 /* UIView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+.swift"; sourceTree = "<group>"; };
 		3F25A35B2C96A76E006E2715 /* StringLiterals.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringLiterals.swift; sourceTree = "<group>"; };
 		3F25A35E2C96A85E006E2715 /* TitleTextFieldView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleTextFieldView.swift; sourceTree = "<group>"; };
@@ -149,6 +155,7 @@
 			children = (
 				3F25A35B2C96A76E006E2715 /* StringLiterals.swift */,
 				3F162B882C9DA71B00DF2E1C /* FontLiterals.swift */,
+				3F1F1F7D2CA3D902006DFD76 /* SizeLiterals.swift */,
 			);
 			path = Consts;
 			sourceTree = "<group>";
@@ -160,6 +167,7 @@
 				3F162B832C9D987300DF2E1C /* LaunchScreenViewController.swift */,
 				3F5960292CA0EE5F00688FE3 /* CustomButton.swift */,
 				3F1F1F772CA27720006DFD76 /* StepCountView.swift */,
+				3F1F1F7B2CA3B858006DFD76 /* CusomSignUpNavigationController.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -195,6 +203,7 @@
 				3F25A3692C96D11A006E2715 /* LoginViewModel.swift */,
 				3F3CFDC12C980B0E00DC9F9A /* UserInfoSignUpViewModel.swift */,
 				3F3CFDBF2C98093700DC9F9A /* UniversityInfoViewModel.swift */,
+				3F1F1F7F2CA3F4CF006DFD76 /* MajorInfoViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -459,14 +468,17 @@
 				3F25A3592C96A676006E2715 /* UIView+.swift in Sources */,
 				3F59602F2CA1422100688FE3 /* UIStackView+.swift in Sources */,
 				3F3CFDAC2C97321700DC9F9A /* UniversityInfoViewController.swift in Sources */,
+				3F1F1F802CA3F4CF006DFD76 /* MajorInfoViewModel.swift in Sources */,
 				3F3CFDB22C973D7E00DC9F9A /* AuthUniversityViewController.swift in Sources */,
 				3F25A35C2C96A76E006E2715 /* StringLiterals.swift in Sources */,
 				3F39925D2C82C8E40045CF1E /* LoginViewController.swift in Sources */,
 				3F3992592C82C8E40045CF1E /* AppDelegate.swift in Sources */,
 				3F3CFDB42C9742C900DC9F9A /* SuccessSignUpViewController.swift in Sources */,
+				3F1F1F7E2CA3D902006DFD76 /* SizeLiterals.swift in Sources */,
 				3F3CFDAE2C97326000DC9F9A /* MajorInfoViewController.swift in Sources */,
 				3F25A3642C96D001006E2715 /* AppCoordinator.swift in Sources */,
 				3F39925B2C82C8E40045CF1E /* SceneDelegate.swift in Sources */,
+				3F1F1F7C2CA3B859006DFD76 /* CusomSignUpNavigationController.swift in Sources */,
 				3F25A3662C96D058006E2715 /* LoginCoordinator.swift in Sources */,
 				3F3CFDBB2C97BE5D00DC9F9A /* UIControl+.swift in Sources */,
 				3F25A36F2C96D42C006E2715 /* SignUpCoordinator.swift in Sources */,

--- a/Studing/Studing/Application/SceneDelegate.swift
+++ b/Studing/Studing/Application/SceneDelegate.swift
@@ -18,7 +18,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
         guard let windowScene = (scene as? UIWindowScene) else { return }
         
-        let navigationController = UINavigationController()
+        let navigationController = CustomSignUpNavigationController()
         appCoordinator = AppCoordinator(navigationController: navigationController)
         
         self.window = UIWindow(windowScene: windowScene)

--- a/Studing/Studing/Coordinators/AppCoordinator.swift
+++ b/Studing/Studing/Coordinators/AppCoordinator.swift
@@ -8,10 +8,10 @@
 import UIKit
 
 final class AppCoordinator: Coordinator {
-    var navigationController: UINavigationController
+    var navigationController: CustomSignUpNavigationController
     var childCoordinators: [Coordinator] = []
     
-    init(navigationController: UINavigationController) {
+    init(navigationController: CustomSignUpNavigationController) {
         self.navigationController = navigationController
     }
     
@@ -55,12 +55,6 @@ final class AppCoordinator: Coordinator {
         childCoordinators.append(loginCoordinator)
         loginCoordinator.delegate = self
         loginCoordinator.start()
-    }
-    
-    private func showSignUpFlow() {
-        let signUpCoordinator = SignUpCoordinator(navigationController: navigationController)
-        childCoordinators.append(signUpCoordinator)
-        signUpCoordinator.start()
     }
 
     private func showMainFlow() {

--- a/Studing/Studing/Coordinators/Coordinator.swift
+++ b/Studing/Studing/Coordinators/Coordinator.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 protocol Coordinator: AnyObject {
-    var navigationController: UINavigationController { get set }
+    var navigationController: CustomSignUpNavigationController { get set }
     var childCoordinators: [Coordinator] { get set }
     func start()
 }

--- a/Studing/Studing/Coordinators/LoginCoordinator.swift
+++ b/Studing/Studing/Coordinators/LoginCoordinator.swift
@@ -12,11 +12,11 @@ protocol LoginCoordinatorDelegate {
 }
 
 final class LoginCoordinator: Coordinator {
-    var navigationController: UINavigationController
+    var navigationController: CustomSignUpNavigationController
     var childCoordinators: [Coordinator] = []
     var delegate: LoginCoordinatorDelegate?
     
-    init(navigationController: UINavigationController) {
+    init(navigationController: CustomSignUpNavigationController) {
         self.navigationController = navigationController
     }
     
@@ -29,7 +29,6 @@ final class LoginCoordinator: Coordinator {
     func showSignUp() {
         let signUpCoordinator = SignUpCoordinator(navigationController: navigationController)
         childCoordinators.append(signUpCoordinator)
-//        signUpCoordinator.parentCoordinator = self
         signUpCoordinator.start()
     }
     

--- a/Studing/Studing/Coordinators/SignUpCoordinator.swift
+++ b/Studing/Studing/Coordinators/SignUpCoordinator.swift
@@ -8,21 +8,24 @@
 import UIKit
 
 final class SignUpCoordinator: Coordinator {
-    var navigationController: UINavigationController
+    var navigationController: CustomSignUpNavigationController
     var childCoordinators: [Coordinator] = []
     weak var parentCoordinator: LoginCoordinator?
     
     var universityName: String?
     var majorName: String?
     
-    init(navigationController: UINavigationController) {
+    init(navigationController: CustomSignUpNavigationController) {
         self.navigationController = navigationController
+        self.navigationController.interactivePopGestureRecognizer?.isEnabled = false
     }
     
     func start() {
         let userInfoSignUpVM = UserInfoSignUpViewModel()
         
         let signUpVC = UserInfoSignUpViewController(viewModel: userInfoSignUpVM, coordinator: self)
+
+        navigationController.changeSignUpStep(count: 1)
         navigationController.pushViewController(signUpVC, animated: true)
     }
 
@@ -31,16 +34,23 @@ final class SignUpCoordinator: Coordinator {
         universityInfoVM.delegate = self
         
         let universityInfoVC = UniversityInfoViewController(viewModel: universityInfoVM, coordinator: self)
+        
+        navigationController.changeSignUpStep(count: 2)
         navigationController.pushViewController(universityInfoVC, animated: true)
     }
     
     func pushMajorInfoView() {
-        let majorInfoVC = MajorInfoViewController()
+        let majorInfoVM = MajorInfoViewModel()
+        let majorInfoVC = MajorInfoViewController(viewModel: majorInfoVM, coordinator: self)
+        
+        navigationController.changeSignUpStep(count: 3)
         navigationController.pushViewController(majorInfoVC, animated: true)
     }
     
     func pushTermsOfServiceView() {
         let termsOfServiceVC = TermsOfServiceViewController()
+        
+        navigationController.changeSignUpStep(count: 4)
         navigationController.pushViewController(termsOfServiceVC, animated: true)
     }
     

--- a/Studing/Studing/Global/Components/CusomSignUpNavigationController.swift
+++ b/Studing/Studing/Global/Components/CusomSignUpNavigationController.swift
@@ -1,0 +1,212 @@
+//
+//  CustomSignUpNavigationController.swift
+//  Studing
+//
+//  Created by ParkJunHyuk on 9/25/24.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+enum LeftButtonType {
+    case xmark
+    case arrow
+}
+
+final class CustomSignUpNavigationController: UINavigationController {
+    
+    // MARK: - Properties
+    private var isPopping = false
+    private let navigationHeight: CGFloat = 60
+    private var signUpStepCount = 1 {
+        didSet {
+            if signUpStepCount - 1 <= 0 {
+                signUpStepCount = 1
+            }
+        }
+    }
+    private var leftButtonType: LeftButtonType = .xmark
+    private var progressBarWidth: CGFloat = 150
+    
+    override var isNavigationBarHidden: Bool {
+        didSet {
+            hideDefaultNavigationBar()
+            safeAreaView.isHidden = isNavigationBarHidden
+            customNavigationBar.isHidden = isNavigationBarHidden
+            setupSafeArea(navigationBarHidden: isNavigationBarHidden)
+        }
+    }
+    
+    // MARK: - UI Properties
+    
+    private let customNavigationBar: UIView = UINavigationBar()
+    private let safeAreaView: UIView = UIView()
+    private let leftButton = UIButton()
+    private let naviTitleLabel = UILabel()
+    private let dividerView = UIView()
+    private let progressbarView = UIView()
+    
+    // MARK: - Life Cycle
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        setupStyle()
+        setupHierarchy()
+        setupLayout()
+        setupDelegate()
+    }
+    
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        progressbarView.applyGradient(colors: [.loginEndGradient, .loginStartGradient], direction: .leftToRight, locations: [0, 1.0])
+        progressbarView.layer.cornerRadius = 2
+    }
+    
+    /// DefaultNavigationBar를 hidden 시켜주는 함수
+    func hideDefaultNavigationBar() {
+        navigationBar.isHidden = true
+    }
+    
+    /// navigationBar가 hidden 상태인지 아닌지에 따라 view의 safeArea를 정해주는 함수
+    func setupSafeArea(navigationBarHidden: Bool) {
+        if navigationBarHidden {
+            additionalSafeAreaInsets = UIEdgeInsets(top: 0,
+                                                    left: 0,
+                                                    bottom: 0,
+                                                    right: 0)
+        } else {
+            additionalSafeAreaInsets = UIEdgeInsets(top: navigationHeight,
+                                                    left: 0,
+                                                    bottom: 0,
+                                                    right: 0)
+        }
+    }
+    
+    func changeLeftButtonType(_ leftButtonType: LeftButtonType) {
+        self.leftButtonType = leftButtonType
+        updateLeftButtonImage()
+    }
+    
+    private func updateLeftButtonImage() {
+        let imageName = signUpStepCount == 1 ? "xmark" : "chevron.left"
+        leftButton.setImage(UIImage(systemName: imageName)?.withConfiguration(UIImage.SymbolConfiguration(pointSize: 24, weight: .regular)), for: .normal)
+    }
+    
+    private func updateProgressBar() {
+        let newWidth = SizeLiterals.Screen.screenWidth * CGFloat(signUpStepCount) / 6.0
+        print(newWidth)
+        
+        progressbarView.snp.remakeConstraints { make in
+            make.top.equalTo(dividerView.snp.bottom)
+            make.leading.equalToSuperview()
+            make.bottom.equalToSuperview()
+            make.height.equalTo(4)
+            make.width.equalTo(newWidth)
+        }
+            
+        UIView.animate(withDuration: 0.3) {
+            print("\(self.signUpStepCount) 진행 중")
+            self.view.layoutIfNeeded()
+        }
+    }
+    
+    func changeSignUpStep(count: Int) {
+        self.signUpStepCount = count
+        updateLeftButtonImage()
+        updateProgressBar()
+    }
+}
+
+// MARK: - Private Extensions
+
+private extension CustomSignUpNavigationController {
+    func setupStyle() {
+        customNavigationBar.do {
+            $0.backgroundColor = .black5
+        }
+        
+        safeAreaView.do {
+            $0.backgroundColor = customNavigationBar.backgroundColor
+        }
+        
+        naviTitleLabel.do {
+            $0.text = "회원가입"
+            $0.font = .interSubtitle1()
+        }
+        
+        dividerView.do {
+            $0.backgroundColor = .black10
+        }
+        
+        leftButton.do {
+            $0.setImage(UIImage(systemName: leftButtonType == .xmark ? "xmark" : "chevron.left")?.withConfiguration(UIImage.SymbolConfiguration(pointSize: 24, weight: .regular)), for: .normal)
+            $0.tintColor = .black50
+            $0.addTarget(self, action: #selector(backButtonTapped), for: .touchUpInside)
+        }
+
+        progressbarView.do {
+            $0.applyGradient(colors: [.loginEndGradient, .loginStartGradient], direction: .leftToRight, locations: [0, 1.0])
+            $0.layer.cornerRadius = 2
+        }
+    }
+    
+    @objc func backButtonTapped() {
+        popViewController(animated: true)
+        signUpStepCount -= 1
+        updateProgressBar()
+        
+        if signUpStepCount == 1 {
+            updateLeftButtonImage()
+        }
+    }
+    
+    func setupHierarchy() {
+        view.addSubviews(safeAreaView, customNavigationBar)
+        
+        customNavigationBar.addSubviews(leftButton, naviTitleLabel, dividerView, progressbarView)
+    }
+    
+    func setupLayout() {
+        customNavigationBar.snp.makeConstraints {
+            $0.height.equalTo(navigationHeight)
+            $0.bottom.equalTo(view.snp.topMargin)
+            $0.horizontalEdges.equalToSuperview()
+        }
+        
+        safeAreaView.snp.makeConstraints {
+            $0.top.equalToSuperview()
+            $0.bottom.equalTo(view.snp.topMargin)
+            $0.horizontalEdges.equalToSuperview()
+        }
+
+        leftButton.snp.makeConstraints {
+            $0.centerY.equalToSuperview()
+            $0.leading.equalToSuperview().offset(20)
+        }
+        
+        naviTitleLabel.snp.makeConstraints {
+            $0.centerX.equalToSuperview()
+            $0.centerY.equalToSuperview()
+        }
+        
+        dividerView.snp.makeConstraints {
+            $0.horizontalEdges.equalToSuperview()
+            $0.height.equalTo(1)
+        }
+        
+        progressbarView.snp.makeConstraints {
+            $0.top.equalTo(dividerView.snp.bottom)
+            $0.leading.equalToSuperview()
+            $0.bottom.equalToSuperview()
+            $0.width.equalTo(SizeLiterals.Screen.screenWidth * CGFloat(signUpStepCount) / 6.0)
+            $0.height.equalTo(4)
+        }
+    }
+    
+    func setupDelegate() {
+
+    }
+}

--- a/Studing/Studing/Global/Components/CustomButton.swift
+++ b/Studing/Studing/Global/Components/CustomButton.swift
@@ -35,7 +35,7 @@ enum ButtonStyle {
         case .notification:
             return "알림 받기"
         case .showStuding:
-            return "스튜딩 구경하기"
+            return "스튜딩 시작하기"
         case .duplicate:
             return "중복확인"
         case .retry:
@@ -55,7 +55,7 @@ enum ButtonStyle {
         case .next, .authentication:
             return .black20
         case .showStuding:
-            return .white
+            return .white.withAlphaComponent(0.1)
         default:
             return .primary50
         }
@@ -97,9 +97,8 @@ class CustomButton: UIButton {
         let titleString = AttributedString(buttonStyle.title, attributes: .init([.font: UIFont.interSubtitle2()]))
         
         if buttonStyle == .showStuding {
-            config.image = UIImage(systemName: "chevron.right")
-            config.imagePlacement = .trailing
-            config.imagePadding = 10
+            config.background.strokeColor = .white
+            config.background.strokeWidth = 1.0
         }
         
         config.attributedTitle = titleString
@@ -109,7 +108,7 @@ class CustomButton: UIButton {
         
         self.configuration = config
         
-        layer.cornerRadius = buttonStyle == .login ? 18 : 10
+        layer.cornerRadius = buttonStyle == .login ? 18 : 25
         clipsToBounds = true
     }
     

--- a/Studing/Studing/Global/Consts/SizeLiterals.swift
+++ b/Studing/Studing/Global/Consts/SizeLiterals.swift
@@ -1,0 +1,16 @@
+//
+//  SizeLiterals.swift
+//  Studing
+//
+//  Created by ParkJunHyuk on 9/25/24.
+//
+
+import UIKit
+
+struct SizeLiterals {
+    struct Screen {
+        static let screenWidth: CGFloat = UIScreen.main.bounds.width
+        static let screenHeight: CGFloat = UIScreen.main.bounds.height
+        static let deviceRatio: CGFloat = screenWidth / screenHeight
+    }
+}

--- a/Studing/Studing/Global/Consts/StringLiterals.swift
+++ b/Studing/Studing/Global/Consts/StringLiterals.swift
@@ -18,6 +18,8 @@ enum StringLiterals {
         static let authUniversity = "학교 정보를 입력해주세요"
         static let authMajor = "학과 정보를 입력해주세요"
         static let authStudentNum = "학번을 선택해주세요"
+        static let authTermsofService = "서비스 이용을 위해\n이용약관 동의가 필요해요"
+        static let authUniversityStudent = "학교 인증을 통해\n스튜딩을 시작할 수 있어요!"
     }
     
     enum Button {
@@ -36,6 +38,7 @@ enum StringLiterals {
         static let AuthenticatingSubTitle1 = "입력한 정보와 제출한 정보가\n일치하는지 확인 중이에요"
         static let AuthenticatingSubTitle2 = "학교 인증이 완료된 이후에\n스튜딩의 모든 기능을 이용할 수 있어요"
         static let AuthenticatingSubTitle3 = "알림을 설정해주시면 학교 인증\n승인 여부를 바로 확인하실 수 있어요!"
-        static let successSignUpTitle = "스튜딩에 오신걸 환영해요!"
+        static let successSignUpTitle = "환영합니다!"
+        static let successSignUpSubTitle = "스튜딩과 함께 대학생의 모든 것을 즐겨봐요"
     }
 }

--- a/Studing/Studing/Present/Login & Signup/ViewController/LoginViewController.swift
+++ b/Studing/Studing/Present/Login & Signup/ViewController/LoginViewController.swift
@@ -62,7 +62,6 @@ final class LoginViewController: UIViewController {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        
         setNavigationBar()
     }
 }
@@ -90,7 +89,6 @@ private extension LoginViewController {
                 self?.coordinator?.showSignUp()
             }
             .store(in: &cancellables)
-            
         
         output.loginResult
             .sink { [weak self] result in

--- a/Studing/Studing/Present/Login & Signup/ViewController/MajorInfoViewController.swift
+++ b/Studing/Studing/Present/Login & Signup/ViewController/MajorInfoViewController.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import Combine
 
 import SnapKit
 import Then
@@ -14,12 +15,30 @@ final class MajorInfoViewController: UIViewController {
     
     // MARK: - Properties
     
+    private var viewModel: MajorInfoViewModel
+    weak var coordinator: SignUpCoordinator?
+    
+    private var cancellables = Set<AnyCancellable>()
+    
     // MARK: - UI Properties
     
     private let stepCountView = StepCountView(count: 3)
     private let majorTitleLabel = UILabel()
     private let majorTitleTextField = TitleTextFieldView(textFieldType: .major)
     private let nextButton = CustomButton(buttonStyle: .next)
+    
+    // MARK: - init
+    
+    init(viewModel: MajorInfoViewModel,
+         coordinator: SignUpCoordinator) {
+        self.viewModel = viewModel
+        self.coordinator = coordinator
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
     
     // MARK: - Life Cycle
     
@@ -34,6 +53,7 @@ final class MajorInfoViewController: UIViewController {
         setupHierarchy()
         setupLayout()
         setupDelegate()
+        bindViewModel()
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -43,7 +63,25 @@ final class MajorInfoViewController: UIViewController {
     }
     
     override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        
         print("Pop MajorInfoViewController")
+    }
+}
+
+// MARK: - Private Bind Extensions
+
+private extension MajorInfoViewController {
+    func bindViewModel() {
+        let input = MajorInfoViewModel.Input(nextTap: nextButton.tapPublisher)
+        
+        let output = viewModel.transform(input: input)
+        
+        output.TermsOfServiceViewAction
+            .sink { [weak self] _ in
+                self?.coordinator?.pushTermsOfServiceView()
+            }
+            .store(in: &cancellables)
     }
 }
 
@@ -51,8 +89,7 @@ final class MajorInfoViewController: UIViewController {
 
 private extension MajorInfoViewController {
     func setNavigationBar() {
-        self.navigationItem.title = StringLiterals.NavigationTitle.signUp
-        self.navigationItem.largeTitleDisplayMode = .inline
+        self.navigationController?.isNavigationBarHidden = false
     }
     
     func setupStyle() {

--- a/Studing/Studing/Present/Login & Signup/ViewController/SuccessSignUpViewController.swift
+++ b/Studing/Studing/Present/Login & Signup/ViewController/SuccessSignUpViewController.swift
@@ -17,8 +17,10 @@ final class SuccessSignUpViewController: UIViewController {
     // MARK: - UI Properties
     
     private let successTitleLabel = UILabel()
+    private let successSubTitleLabel = UILabel()
     private let logoImage = UIImageView()
-    private let pushMainHomeButton = UIButton()
+    private let studingTitleLabel = UILabel()
+    private let pushMainHomeButton = CustomButton(buttonStyle: .showStuding)
     
     // MARK: - Life Cycle
     
@@ -26,6 +28,8 @@ final class SuccessSignUpViewController: UIViewController {
         super.viewDidLoad()
         
         print("Push SuccessSignUpViewController")
+        
+        view.applyGradient(colors: [.loginStartGradient, .loginEndGradient], direction: .topRightToBottomLeft, locations: [-0.2, 1.3])
         
         setupStyle()
         setupHierarchy()
@@ -54,10 +58,24 @@ private extension SuccessSignUpViewController {
     func setupStyle() {
         successTitleLabel.do {
             $0.text = StringLiterals.Authentication.successSignUpTitle
+            $0.textColor = .white
+            $0.font = .interHeadline2()
+        }
+        
+        successSubTitleLabel.do {
+            $0.text = StringLiterals.Authentication.successSignUpSubTitle
+            $0.textColor = .white
+            $0.font = .interBody1()
         }
         
         pushMainHomeButton.do {
             $0.setTitle(StringLiterals.Button.pushMainHomeTitle, for: .normal)
+        }
+        
+        studingTitleLabel.do {
+            $0.text = "Studing"
+            $0.textColor = .white
+            $0.font = .montserratExtraBold(size: 34)
         }
     }
     
@@ -70,13 +88,18 @@ private extension SuccessSignUpViewController {
             $0.top.equalToSuperview().offset(view.convertByHeightRatio(256))
         }
         
+        successSubTitleLabel.snp.makeConstraints {
+            $0.top.equalTo(successSubTitleLabel.snp.bottom).offset(10)
+        }
+        
         logoImage.snp.makeConstraints {
-            $0.top.equalTo(successTitleLabel.snp.bottom).offset(35)
+            $0.top.equalTo(successSubTitleLabel.snp.bottom).offset(38)
         }
         
         pushMainHomeButton.snp.makeConstraints {
             $0.leading.equalToSuperview().offset(20)
             $0.trailing.equalToSuperview().inset(19)
+            $0.height.equalTo(60)
             $0.bottom.equalToSuperview().offset(view.convertByHeightRatio(-35))
         }
     }

--- a/Studing/Studing/Present/Login & Signup/ViewController/TermsOfServiceViewController.swift
+++ b/Studing/Studing/Present/Login & Signup/ViewController/TermsOfServiceViewController.swift
@@ -16,7 +16,9 @@ final class TermsOfServiceViewController: UIViewController {
     
     // MARK: - UI Properties
     
-    private let nextButton = UIButton()
+    private let stepCountView = StepCountView(count: 5)
+    private let serviceTitleLabel = UILabel()
+    private let nextButton = CustomButton(buttonStyle: .next)
     
     // MARK: - Life Cycle
     
@@ -24,6 +26,7 @@ final class TermsOfServiceViewController: UIViewController {
         super.viewDidLoad()
         
         print("Push TermsOfServiceViewController")
+        view.backgroundColor = .signupBackground
         
         setupStyle()
         setupHierarchy()
@@ -38,6 +41,8 @@ final class TermsOfServiceViewController: UIViewController {
     }
     
     override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        
         print("Pop TermsOfServiceViewController")
     }
 }
@@ -46,20 +51,38 @@ final class TermsOfServiceViewController: UIViewController {
 
 private extension TermsOfServiceViewController {
     func setNavigationBar() {
-        self.navigationItem.title = StringLiterals.NavigationTitle.signUp
-        self.navigationItem.largeTitleDisplayMode = .inline
+        self.navigationController?.isNavigationBarHidden = false
     }
     
     func setupStyle() {
-        
+        serviceTitleLabel.do {
+            $0.text = StringLiterals.Title.authTermsofService
+            $0.font = .interHeadline2()
+            $0.textColor = .black50
+            $0.numberOfLines = 2
+        }
     }
     
     func setupHierarchy() {
-        
+        view.addSubviews(stepCountView, serviceTitleLabel,  nextButton)
     }
     
     func setupLayout() {
+        stepCountView.snp.makeConstraints {
+            $0.top.equalTo(view.safeAreaLayoutGuide.snp.top).offset(view.convertByHeightRatio(20))
+            $0.leading.equalToSuperview().offset(19)
+        }
         
+        serviceTitleLabel.snp.makeConstraints {
+            $0.top.equalTo(stepCountView.snp.bottom).offset(view.convertByHeightRatio(15))
+            $0.horizontalEdges.equalToSuperview().inset(19)
+        }
+        
+        nextButton.snp.makeConstraints {
+            $0.horizontalEdges.equalToSuperview().inset(20)
+            $0.bottom.equalTo(view.safeAreaLayoutGuide.snp.bottom).inset(8)
+            $0.height.equalTo(50)
+        }
     }
     
     func setupDelegate() {

--- a/Studing/Studing/Present/Login & Signup/ViewController/UniversityInfoViewController.swift
+++ b/Studing/Studing/Present/Login & Signup/ViewController/UniversityInfoViewController.swift
@@ -58,7 +58,7 @@ final class UniversityInfoViewController: UIViewController {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        
+        print("wiewWill UniversityInfoViewController")
         setNavigationBar()
     }
     
@@ -89,8 +89,7 @@ private extension UniversityInfoViewController {
 
 private extension UniversityInfoViewController {
     func setNavigationBar() {
-        self.navigationItem.title = StringLiterals.NavigationTitle.signUp
-        self.navigationItem.largeTitleDisplayMode = .inline
+        self.navigationController?.isNavigationBarHidden = false
     }
     
     func setupStyle() {

--- a/Studing/Studing/Present/Login & Signup/ViewController/UserInfoSignUpViewController.swift
+++ b/Studing/Studing/Present/Login & Signup/ViewController/UserInfoSignUpViewController.swift
@@ -48,7 +48,7 @@ final class UserInfoSignUpViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        print("Push SignUpViewController")
+        print("Push UserInfoSignUpViewController")
         view.backgroundColor = .signupBackground
         
         hideKeyboard()
@@ -68,7 +68,7 @@ final class UserInfoSignUpViewController: UIViewController {
     override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
         
-        print("Pop SignUpViewController")
+        print("Pop UserInfoSignUpViewController")
     }
 }
 
@@ -87,7 +87,8 @@ private extension UserInfoSignUpViewController {
         
         /// 다음 버튼이 눌릴 수 있는지
         output.isNextButtonEnabled
-            .map { $0 ? ButtonState.activate : ButtonState.deactivate }
+//            .map { $0 ? ButtonState.activate : ButtonState.deactivate }
+            .map { _ in .activate }
             .assign(to: \.buttonState, on: nextButton)
             .store(in: &cancellables)
         
@@ -132,9 +133,7 @@ private extension UserInfoSignUpViewController {
 
 private extension UserInfoSignUpViewController {
     func setNavigationBar() {
-        self.navigationController?.setNavigationBarHidden(false, animated: true)
-        self.navigationItem.title = StringLiterals.NavigationTitle.signUp
-        self.navigationItem.largeTitleDisplayMode = .inline
+        self.navigationController?.isNavigationBarHidden = false
     }
     
     func setupStyle() {

--- a/Studing/Studing/Present/Login & Signup/ViewModel/MajorInfoViewModel.swift
+++ b/Studing/Studing/Present/Login & Signup/ViewModel/MajorInfoViewModel.swift
@@ -1,0 +1,36 @@
+//
+//  MajorInfoViewModel.swift
+//  Studing
+//
+//  Created by ParkJunHyuk on 9/25/24.
+//
+
+import Foundation
+import Combine
+
+final class MajorInfoViewModel: BaseViewModel {
+    
+    // MARK: - Input
+    
+    struct Input {
+        let nextTap: AnyPublisher<Void, Never>
+    }
+    
+    // MARK: - Output
+    
+    struct Output {
+        let TermsOfServiceViewAction: AnyPublisher<Void, Never>
+    }
+    
+    // MARK: - Private properties
+    
+    private var cancellables = Set<AnyCancellable>()
+    
+    
+    // MARK: - Public methods
+    
+    func transform(input: Input) -> Output {
+        
+        return Output(TermsOfServiceViewAction: input.nextTap)
+    }
+}


### PR DESCRIPTION
## 📟 관련 이슈
- Resolved: #11

<br>

## 👷 작업한 내용
<!-- 작업한 내용을 적어주세요. -->
- 회원가입 시 상단의 NavigationBar 를 위한 `CustomSignUpNavigationController` 구현
- 회원가입 관련 ViewController UI 및 ViewModel 구현
- `showStuding` Type 의 `UIButton` UI 변경
- `Coordinator` 에서 `CustomSignUpNavigationController` 로 `NavigationController` 변경 

<br>

## 📸 스크린샷
|기능|2번째 페이지|3번째 페이지|
|:--:|:--:|:--:|
|Img|<img src = "https://github.com/user-attachments/assets/5c57d8dd-4653-4003-b56c-0a7f0964c17e" width ="250">|<img src = "https://github.com/user-attachments/assets/ff324449-f6d6-47c1-9f85-c4cf43a008a2" width ="250">|

<br>

## 🚨 참고 사항
<!-- 참고 사항을 적어주세요. 없으면 지워주세요. -->

### `CustomSignUpNavigationController`

``` swift
/// navigationBar가 hidden 상태인지 아닌지에 따라 view의 safeArea를 정해주는 함수
func setupSafeArea(navigationBarHidden: Bool) {
    if navigationBarHidden {
        additionalSafeAreaInsets = UIEdgeInsets(top: 0,
                                                left: 0,
                                                bottom: 0,
                                                right: 0)
    } else {
        additionalSafeAreaInsets = UIEdgeInsets(top: navigationHeight,
                                                left: 0,
                                                bottom: 0,
                                                right: 0)
    }
}
```

`UINavigationController` 를 직접 다루게 되면 시스템에서 자동으로 safe area 를 관리하지 않습니다....
해당 `navigationBar` 가 숨겨져 있다면 `SafeArea` 를 없애고 존재한다면 `SafeArea` 를 `navigationBar` 의 높이 만큼 적용하여 `SafeArea` 를 직접 적용해주시면 됩니다.

<br>

## ✅ Checklist
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
