### PR TITLE
[Feat] #39 - FCM 관련 세팅 및 저장 API 구현

### DIFF
--- a/Studing/Studing.xcodeproj/project.pbxproj
+++ b/Studing/Studing.xcodeproj/project.pbxproj
@@ -149,6 +149,7 @@
 		3F54DA182CE5369000314B46 /* BookmarkListEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F54DA172CE5369000314B46 /* BookmarkListEntity.swift */; };
 		3F54DA1A2CE5958B00314B46 /* EmptyBookmarkListCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F54DA192CE5958B00314B46 /* EmptyBookmarkListCollectionViewCell.swift */; };
 		3F54DA1C2CE59BCB00314B46 /* AskStudingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F54DA1B2CE59BCB00314B46 /* AskStudingView.swift */; };
+		3F54DA1E2CE5C39600314B46 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3F54DA1D2CE5C39500314B46 /* GoogleService-Info.plist */; };
 		3F57612F2CC78F8E0039AC11 /* AllAssociationAnnounceListEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F57612E2CC78F8E0039AC11 /* AllAssociationAnnounceListEntity.swift */; };
 		3F59602A2CA0EE5F00688FE3 /* CustomButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F5960292CA0EE5F00688FE3 /* CustomButton.swift */; };
 		3F59602D2CA13E8F00688FE3 /* TextFieldEnum.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F59602C2CA13E8F00688FE3 /* TextFieldEnum.swift */; };
@@ -162,6 +163,11 @@
 		3F82C3392CAE94A600492EEE /* NSObject+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F82C3382CAE94A600492EEE /* NSObject+.swift */; };
 		3F82C33B2CAE94CB00492EEE /* UniversityInfoModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F82C33A2CAE94CB00492EEE /* UniversityInfoModel.swift */; };
 		3F82C33D2CAE94E000492EEE /* MajorInfoModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F82C33C2CAE94E000492EEE /* MajorInfoModel.swift */; };
+		3F92633E2CE5CF5B00ADC1EB /* NotificationsAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F92633D2CE5CF5B00ADC1EB /* NotificationsAPI.swift */; };
+		3F9263422CE5D05D00ADC1EB /* NotificationTokenRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F9263412CE5D05D00ADC1EB /* NotificationTokenRequestDTO.swift */; };
+		3F9263442CE5D08F00ADC1EB /* NotificationRepositoryImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F9263432CE5D08F00ADC1EB /* NotificationRepositoryImpl.swift */; };
+		3F9263462CE5D0AB00ADC1EB /* NotificationsRepositoryProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F9263452CE5D0AB00ADC1EB /* NotificationsRepositoryProtocol.swift */; };
+		3F9263492CE5D1A600ADC1EB /* NotificationTokenUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F9263482CE5D1A600ADC1EB /* NotificationTokenUseCase.swift */; };
 		3F977C192CD1F27E00A3FE56 /* CustomAnnouceNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F977C182CD1F27E00A3FE56 /* CustomAnnouceNavigationController.swift */; };
 		3F9DC8A82CB4ECA900850136 /* StudentIdInputCollectionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F9DC8A72CB4ECA900850136 /* StudentIdInputCollectionCell.swift */; };
 		3F9DC8AC2CB4ECE000850136 /* StudentIdInfoModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F9DC8AB2CB4ECE000850136 /* StudentIdInfoModel.swift */; };
@@ -367,6 +373,7 @@
 		3F54DA172CE5369000314B46 /* BookmarkListEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkListEntity.swift; sourceTree = "<group>"; };
 		3F54DA192CE5958B00314B46 /* EmptyBookmarkListCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyBookmarkListCollectionViewCell.swift; sourceTree = "<group>"; };
 		3F54DA1B2CE59BCB00314B46 /* AskStudingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AskStudingView.swift; sourceTree = "<group>"; };
+		3F54DA1D2CE5C39500314B46 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		3F57612E2CC78F8E0039AC11 /* AllAssociationAnnounceListEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AllAssociationAnnounceListEntity.swift; sourceTree = "<group>"; };
 		3F5960292CA0EE5F00688FE3 /* CustomButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomButton.swift; sourceTree = "<group>"; };
 		3F59602C2CA13E8F00688FE3 /* TextFieldEnum.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextFieldEnum.swift; sourceTree = "<group>"; };
@@ -380,6 +387,12 @@
 		3F82C3382CAE94A600492EEE /* NSObject+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSObject+.swift"; sourceTree = "<group>"; };
 		3F82C33A2CAE94CB00492EEE /* UniversityInfoModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UniversityInfoModel.swift; sourceTree = "<group>"; };
 		3F82C33C2CAE94E000492EEE /* MajorInfoModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MajorInfoModel.swift; sourceTree = "<group>"; };
+		3F92633B2CE5CD0B00ADC1EB /* Studing.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Studing.entitlements; sourceTree = "<group>"; };
+		3F92633D2CE5CF5B00ADC1EB /* NotificationsAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationsAPI.swift; sourceTree = "<group>"; };
+		3F9263412CE5D05D00ADC1EB /* NotificationTokenRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationTokenRequestDTO.swift; sourceTree = "<group>"; };
+		3F9263432CE5D08F00ADC1EB /* NotificationRepositoryImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationRepositoryImpl.swift; sourceTree = "<group>"; };
+		3F9263452CE5D0AB00ADC1EB /* NotificationsRepositoryProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationsRepositoryProtocol.swift; sourceTree = "<group>"; };
+		3F9263482CE5D1A600ADC1EB /* NotificationTokenUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationTokenUseCase.swift; sourceTree = "<group>"; };
 		3F977C182CD1F27E00A3FE56 /* CustomAnnouceNavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomAnnouceNavigationController.swift; sourceTree = "<group>"; };
 		3F9DC8A72CB4ECA900850136 /* StudentIdInputCollectionCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StudentIdInputCollectionCell.swift; sourceTree = "<group>"; };
 		3F9DC8AB2CB4ECE000850136 /* StudentIdInfoModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StudentIdInfoModel.swift; sourceTree = "<group>"; };
@@ -692,6 +705,7 @@
 		3F3992572C82C8E40045CF1E /* Studing */ = {
 			isa = PBXGroup;
 			children = (
+				3F92633B2CE5CD0B00ADC1EB /* Studing.entitlements */,
 				3FFCFEE12CE0D386009D07A6 /* Data */,
 				3FFCFEE02CE0D37F009D07A6 /* Domain */,
 				3F39927D2C82D2440045CF1E /* Application */,
@@ -721,6 +735,7 @@
 		3F39927B2C82D22A0045CF1E /* Network */ = {
 			isa = PBXGroup;
 			children = (
+				3F92633C2CE5CF4B00ADC1EB /* Notifications */,
 				3F54D9752CE190D200314B46 /* Notices */,
 				3F54D9722CE1174900314B46 /* Home */,
 				3F54D96F2CE115FF00314B46 /* UniversityData */,
@@ -757,6 +772,7 @@
 				3F162B812C9D92B300DF2E1C /* Color.xcassets */,
 				3F54D96A2CE10B7F00314B46 /* Config.xcconfig */,
 				3F54D96B2CE10B8900314B46 /* Config.swift */,
+				3F54DA1D2CE5C39500314B46 /* GoogleService-Info.plist */,
 			);
 			path = Resoureces;
 			sourceTree = "<group>";
@@ -1030,6 +1046,38 @@
 			path = Enum;
 			sourceTree = "<group>";
 		};
+		3F92633C2CE5CF4B00ADC1EB /* Notifications */ = {
+			isa = PBXGroup;
+			children = (
+				3F92633D2CE5CF5B00ADC1EB /* NotificationsAPI.swift */,
+			);
+			path = Notifications;
+			sourceTree = "<group>";
+		};
+		3F92633F2CE5D04600ADC1EB /* Notifications */ = {
+			isa = PBXGroup;
+			children = (
+				3F9263402CE5D05100ADC1EB /* Request */,
+			);
+			path = Notifications;
+			sourceTree = "<group>";
+		};
+		3F9263402CE5D05100ADC1EB /* Request */ = {
+			isa = PBXGroup;
+			children = (
+				3F9263412CE5D05D00ADC1EB /* NotificationTokenRequestDTO.swift */,
+			);
+			path = Request;
+			sourceTree = "<group>";
+		};
+		3F9263472CE5D19300ADC1EB /* Notifications */ = {
+			isa = PBXGroup;
+			children = (
+				3F9263482CE5D1A600ADC1EB /* NotificationTokenUseCase.swift */,
+			);
+			path = Notifications;
+			sourceTree = "<group>";
+		};
 		3F9DC8A62CB4EC0000850136 /* View */ = {
 			isa = PBXGroup;
 			children = (
@@ -1150,6 +1198,7 @@
 		3FFCFEE22CE0D38E009D07A6 /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				3F92633F2CE5D04600ADC1EB /* Notifications */,
 				3F54D9E92CE4D29A00314B46 /* Notices */,
 				3F54D9892CE19BDA00314B46 /* Home */,
 				3F54D9832CE19A4B00314B46 /* UniversityData */,
@@ -1171,6 +1220,7 @@
 		3FFCFEE42CE0D39C009D07A6 /* UseCases */ = {
 			isa = PBXGroup;
 			children = (
+				3F9263472CE5D19300ADC1EB /* Notifications */,
 				3F54D9E42CE4D07500314B46 /* Notices */,
 				3F54D9C72CE364D900314B46 /* Home */,
 				3F54D9B22CE2116E00314B46 /* UniversityData */,
@@ -1186,6 +1236,7 @@
 				3F54D9B82CE2127000314B46 /* UniversityDataRepositoryProtocol.swift */,
 				3F54D9C82CE3650400314B46 /* HomeRepositoryProtocol.swift */,
 				3F54D9E72CE4D0EB00314B46 /* NoticesRepositoryProtocol.swift */,
+				3F9263452CE5D0AB00ADC1EB /* NotificationsRepositoryProtocol.swift */,
 			);
 			path = Repositories;
 			sourceTree = "<group>";
@@ -1197,6 +1248,7 @@
 				3F54D9B62CE2125600314B46 /* UniversityDataRepositoryImpl.swift */,
 				3F54D9CE2CE3681E00314B46 /* HomeRepositoryImpl.swift */,
 				3F54D9FE2CE4DC0200314B46 /* NoticesRepositoryImpl.swift */,
+				3F9263432CE5D08F00ADC1EB /* NotificationRepositoryImpl.swift */,
 			);
 			path = Repositories;
 			sourceTree = "<group>";
@@ -1321,6 +1373,7 @@
 				3F162B8B2C9DAACC00DF2E1C /* Inter-VariableFont_opsz,wght.ttf in Resources */,
 				3F162B8D2C9DBA0D00DF2E1C /* LaunchScreen.storyboard in Resources */,
 				3F162B822C9D92B300DF2E1C /* Color.xcassets in Resources */,
+				3F54DA1E2CE5C39600314B46 /* GoogleService-Info.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1414,6 +1467,7 @@
 				3F25A35C2C96A76E006E2715 /* StringLiterals.swift in Sources */,
 				3F54DA0F2CE4DF9E00314B46 /* BookmarkAnnouceUseCase.swift in Sources */,
 				3FB203492CC5C409003F381D /* AssociationEntity.swift in Sources */,
+				3F9263442CE5D08F00ADC1EB /* NotificationRepositoryImpl.swift in Sources */,
 				3F54DA1A2CE5958B00314B46 /* EmptyBookmarkListCollectionViewCell.swift in Sources */,
 				3FB2034D2CC5C435003F381D /* MissAnnounceEntity.swift in Sources */,
 				3F1739722CBEB45F00DE8859 /* AuthWaitCheckView.swift in Sources */,
@@ -1433,11 +1487,13 @@
 				3F54D9F12CE4D41F00314B46 /* AllAssociationAnnouceListResponseDTO.swift in Sources */,
 				3F17396E2CBE495200DE8859 /* AuthUniversityViewModel.swift in Sources */,
 				3F54D9932CE19D6400314B46 /* UnreadAssocationAnnouceCountResponseDTO.swift in Sources */,
+				3F92633E2CE5CF5B00ADC1EB /* NotificationsAPI.swift in Sources */,
 				3F1F1F7E2CA3D902006DFD76 /* SizeLiterals.swift in Sources */,
 				3F54DA162CE4F50900314B46 /* AllAnnounceEntity.swift in Sources */,
 				3FD4B91C2CDCD5BB00308E08 /* BenefitListCollectionViewCell.swift in Sources */,
 				3FD4B9132CDC4F6E00308E08 /* StoreModel.swift in Sources */,
 				3F54D9BD2CE2134D00314B46 /* DepartmentListUseCase.swift in Sources */,
+				3F9263492CE5D1A600ADC1EB /* NotificationTokenUseCase.swift in Sources */,
 				3F54D9AF2CE1C3F900314B46 /* NetworkError.swift in Sources */,
 				3FD4B9112CDBDA1500308E08 /* StoreViewModel.swift in Sources */,
 				3FE0433B2CC7710A00B55EAA /* AnnounceListViewModel.swift in Sources */,
@@ -1491,6 +1547,7 @@
 				3F54D9F52CE4D5EE00314B46 /* BookmarkAssociationAnnounceListRequestDTO.swift in Sources */,
 				3F54D99E2CE1A15600314B46 /* String+.swift in Sources */,
 				3F3CFDC02C98093700DC9F9A /* UniversityInfoViewModel.swift in Sources */,
+				3F9263462CE5D0AB00ADC1EB /* NotificationsRepositoryProtocol.swift in Sources */,
 				3F1739702CBE496100DE8859 /* AuthWaitingViewModel.swift in Sources */,
 				3FE043332CC693EF00B55EAA /* AnnounceListViewController.swift in Sources */,
 				3F1739802CC0187B00DE8859 /* MypageCoordinator.swift in Sources */,
@@ -1510,6 +1567,7 @@
 				3F54D9F32CE4D59300314B46 /* BookmarkAssociationAnnounceListResponseDTO.swift in Sources */,
 				3F54D9802CE1998C00314B46 /* SignupRequsetDTO.swift in Sources */,
 				3F17396C2CBE442E00DE8859 /* CustomButtonEnum.swift in Sources */,
+				3F9263422CE5D05D00ADC1EB /* NotificationTokenRequestDTO.swift in Sources */,
 				3FB2034B2CC5C41A003F381D /* AssociationAnnounceModel.swift in Sources */,
 				3F54D98C2CE19C2A00314B46 /* UniversityLogoResponseDTO.swift in Sources */,
 				3FE042FA2CC5D38F00B55EAA /* MyInfoCollectionViewCell.swift in Sources */,
@@ -1682,6 +1740,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = Studing/Studing.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = N3H27N59VG;
@@ -1712,6 +1771,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = Studing/Studing.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = N3H27N59VG;

--- a/Studing/Studing/Coordinators/LoginCoordinator.swift
+++ b/Studing/Studing/Coordinators/LoginCoordinator.swift
@@ -21,7 +21,7 @@ final class LoginCoordinator: Coordinator {
     }
     
     func start() {
-        let loginViewModel = LoginViewModel(signInUseCase: SignInUseCase(repository: MemberRepositoryImpl()))
+        let loginViewModel = LoginViewModel(signInUseCase: SignInUseCase(repository: MemberRepositoryImpl()), notificationTokenUseCase: NotificationTokenUseCase(repository: NotificationsRepositoryImpl()))
         let loginVC = LoginViewController(viewModel: loginViewModel, coordinator: self)
         navigationController.pushViewController(loginVC, animated: true)
     }

--- a/Studing/Studing/Coordinators/SignUpCoordinator.swift
+++ b/Studing/Studing/Coordinators/SignUpCoordinator.swift
@@ -73,6 +73,9 @@ final class SignUpCoordinator: Coordinator {
     
     func pushTermsOfServiceView() {
         let termsOfServiceVM = TermsOfServiceViewModel()
+        
+        termsOfServiceVM.delegate = self
+        
         let termsOfServiceVC = TermsOfServiceViewController(viewModel: termsOfServiceVM, coordinator: self)
         
         navigationController.changeSignUpStep(count: 5)
@@ -137,6 +140,12 @@ extension SignUpCoordinator: InputMajorDelegate {
 extension SignUpCoordinator: InputAdmissionDelegate {
     func didSubmitAdmission(_ admission: String) {
         signUpStore.setAdmission(admission)
+    }
+}
+
+extension SignUpCoordinator: InputmarketingDelegate {
+    func didSubmitMarketing(_ isMarketing: Bool) {
+        signUpStore.setMarketing(isMarketing)
     }
 }
 

--- a/Studing/Studing/Data/Models/Member/Requset/SignupRequsetDTO.swift
+++ b/Studing/Studing/Data/Models/Member/Requset/SignupRequsetDTO.swift
@@ -16,4 +16,5 @@ struct SignupRequestDTO: Encodable {
     let memberUniversity: String      // 사용자 대학교이름
     let memberDepartment: String      // 사용자 대학교 학과
     let studentCardImage: Data        // 학생증 사진
+    let marketingAgreement: Bool      // 마켓팅 수신 동의 유/무
 }

--- a/Studing/Studing/Data/Models/Notifications/Request/NotificationTokenRequestDTO.swift
+++ b/Studing/Studing/Data/Models/Notifications/Request/NotificationTokenRequestDTO.swift
@@ -1,0 +1,12 @@
+//
+//  NotificationTokenRequestDTO.swift
+//  Studing
+//
+//  Created by ParkJunHyuk on 11/14/24.
+//
+
+import Foundation
+
+struct NotificationTokenRequestDTO: Codable {
+    let fcmToken: String
+}

--- a/Studing/Studing/Data/Repositories/NotificationRepositoryImpl.swift
+++ b/Studing/Studing/Data/Repositories/NotificationRepositoryImpl.swift
@@ -1,0 +1,16 @@
+//
+//  NotificationRepositoryImpl.swift
+//  Studing
+//
+//  Created by ParkJunHyuk on 11/14/24.
+//
+
+import Foundation
+
+import Foundation
+
+final class NotificationsRepositoryImpl: NotificationsRepository {
+    func postNotificationToken() async -> Result<EmptyResponse, NetworkError> {
+        return await NetworkManager.shared.request(NotificationsAPI.postNotificationToken(NotificationTokenRequestDTO(fcmToken: KeychainManager.shared.load(key: .fcmToken) ?? "")))
+    }
+}

--- a/Studing/Studing/Domain/Repositories/NotificationsRepositoryProtocol.swift
+++ b/Studing/Studing/Domain/Repositories/NotificationsRepositoryProtocol.swift
@@ -1,0 +1,12 @@
+//
+//  NotificationsRepositoryProtocol.swift
+//  Studing
+//
+//  Created by ParkJunHyuk on 11/14/24.
+//
+
+import Foundation
+
+protocol NotificationsRepository {
+    func postNotificationToken() async -> Result<EmptyResponse, NetworkError>
+}

--- a/Studing/Studing/Domain/UseCases/Notifications/NotificationTokenUseCase.swift
+++ b/Studing/Studing/Domain/UseCases/Notifications/NotificationTokenUseCase.swift
@@ -1,0 +1,20 @@
+//
+//  NotificationTokenUseCase.swift
+//  Studing
+//
+//  Created by ParkJunHyuk on 11/14/24.
+//
+
+import Foundation
+
+final class NotificationTokenUseCase {
+    private let repository: NotificationsRepository
+    
+    init(repository: NotificationsRepository) {
+        self.repository = repository
+    }
+    
+    func execute() async -> Result<EmptyResponse,NetworkError> {
+        return await repository.postNotificationToken()
+    }
+}

--- a/Studing/Studing/Global/Protocol/SignUpDelegate.swift
+++ b/Studing/Studing/Global/Protocol/SignUpDelegate.swift
@@ -24,6 +24,10 @@ protocol InputAdmissionDelegate: AnyObject {
     func didSubmitAdmission(_ admission: String)
 }
 
+protocol InputmarketingDelegate: AnyObject {
+    func didSubmitMarketing(_ isMarketing: Bool)
+}
+
 protocol InputStudentInfoDelegate: AnyObject {
     func didSubmitStudentCardImage(_ imageData: Data)
     func didSubmitUserName(_ userName: String)

--- a/Studing/Studing/Global/Resoureces/Config.swift
+++ b/Studing/Studing/Global/Resoureces/Config.swift
@@ -16,6 +16,7 @@ enum Config {
         enum Keychain: String {
             case accessToken = "ACCESS_TOKEN_KEY"
             case refreshToken = "REFRESH_TOKEN_KEY"
+            case fcmToken = "FCM_TOKEN_KEY"
         }
     }
     
@@ -49,5 +50,11 @@ extension Config {
         return key
     }()
     
+    static let fcmTokenKey: String = {
+        guard let key = Config.infoDictionary[Keys.Keychain.fcmToken.rawValue] as? String else {
+            fatalError("⛔️FCM_TOKEN_KEY is not set in plist for this configuration⛔️")
+        }
+        return key
+    }()
 }
 

--- a/Studing/Studing/Global/Supporting Files/Info.plist
+++ b/Studing/Studing/Global/Supporting Files/Info.plist
@@ -6,6 +6,8 @@
 	<string>$(ACCESS_TOKEN_KEY)</string>
 	<key>BASE_URL</key>
 	<string>$(BASE_URL)</string>
+	<key>FCM_TOKEN_KEY</key>
+	<string>$(FCM_TOKEN_KEY)</string>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>
@@ -36,5 +38,9 @@
 			</array>
 		</dict>
 	</dict>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>remote-notification</string>
+	</array>
 </dict>
 </plist>

--- a/Studing/Studing/Network/KeychainManager.swift
+++ b/Studing/Studing/Network/KeychainManager.swift
@@ -28,6 +28,8 @@ enum KeychainKey: String {
     /// 리프레시 토큰을 저장하기 위한 키
     case refreshToken
     
+    case fcmToken
+    
     /// Info.plist에서 정의된 실제 키체인 키 값을 반환합니다.
         /// - Returns: Info.plist에 정의된 실제 키 문자열
     var value: String {
@@ -36,6 +38,8 @@ enum KeychainKey: String {
             return Config.accessTokenKey
         case .refreshToken:
             return Config.refreshTokenKey
+        case .fcmToken:
+            return Config.fcmTokenKey
         }
     }
 }
@@ -106,6 +110,8 @@ final class KeychainManager {
         
         if status == errSecSuccess {
             if let data = dataTypeRef as? Data {
+                
+                print("KeyChain - \(key) 불러오기 완료")
                 return String(data: data, encoding: .utf8)
             }
         }

--- a/Studing/Studing/Network/Notifications/NotificationsAPI.swift
+++ b/Studing/Studing/Network/Notifications/NotificationsAPI.swift
@@ -1,0 +1,44 @@
+//
+//  NotificationsAPI.swift
+//  Studing
+//
+//  Created by ParkJunHyuk on 11/14/24.
+//
+
+import Alamofire
+
+enum NotificationsAPI {
+    case postNotificationToken(NotificationTokenRequestDTO)
+}
+
+extension NotificationsAPI: APIEndpoint {
+    var basePath: BasePath {
+        return .notifications
+    }
+    
+    var path: String {
+        switch self {
+        case .postNotificationToken:
+            return basePath.rawValue + "/token"
+        }
+    }
+    
+    var method: Alamofire.HTTPMethod {
+        return .post
+    }
+    
+    var headerType: HeaderType {
+        return .accessTokenHeader
+    }
+    
+    var requestBodyType: RequestBodyType {
+        return .json
+    }
+    
+    var parameters: (any Encodable)? {
+        switch self {
+        case .postNotificationToken(let dto):
+            return dto
+        }
+    }
+}

--- a/Studing/Studing/Presentation/Login & Signup/SignUpStore.swift
+++ b/Studing/Studing/Presentation/Login & Signup/SignUpStore.swift
@@ -44,6 +44,7 @@ final class SignUpStore: UserInfoStoreProtocol, UniversityInfoStoreProtocol, Stu
     private(set) var university: String?
     private(set) var major: String?
     private(set) var admission: String?
+    private(set) var marketing: Bool?
     private(set) var studentCardImage: Data?
     private(set) var userName: String?
     private(set) var studentNumber: String?
@@ -81,6 +82,11 @@ final class SignUpStore: UserInfoStoreProtocol, UniversityInfoStoreProtocol, Stu
         self.admission = admission
     }
     
+    func setMarketing(_ isMarketing: Bool) {
+        print("마켓팅 수신동의 입력:", isMarketing)
+        self.marketing = isMarketing
+    }
+    
     func setStudentCardImage(_ image: Data) {
         print("학생증 입력")
         self.studentCardImage = image
@@ -103,6 +109,7 @@ final class SignUpStore: UserInfoStoreProtocol, UniversityInfoStoreProtocol, Stu
              let admission = admission,
              let studentNumber = studentNumber,
              let userName = userName,
+             let marketing = marketing,
              let university = university,
              let major = major,
              let studentCardImage = studentCardImage else {
@@ -118,7 +125,8 @@ final class SignUpStore: UserInfoStoreProtocol, UniversityInfoStoreProtocol, Stu
            studentNumber: studentNumber,
            memberUniversity: university,
            memberDepartment: major,
-           studentCardImage: studentCardImage
+           studentCardImage: studentCardImage,
+           marketingAgreement: marketing
        )
    }
     
@@ -128,6 +136,7 @@ final class SignUpStore: UserInfoStoreProtocol, UniversityInfoStoreProtocol, Stu
         university = nil
         major = nil
         admission = nil
+        marketing = nil
         studentCardImage = nil
         userName = nil
         studentNumber = nil

--- a/Studing/Studing/Presentation/Login & Signup/ViewController/AuthUniversityViewController.swift
+++ b/Studing/Studing/Presentation/Login & Signup/ViewController/AuthUniversityViewController.swift
@@ -300,7 +300,7 @@ extension AuthUniversityViewController: PHPickerViewControllerDelegate {
                 DispatchQueue.main.async {
                     guard let self, let image = image as? UIImage else { return }
                     
-                    if let imageData = image.jpegData(compressionQuality: 0.1) {
+                    if let imageData = image.jpegData(compressionQuality: 0.05) {
                         
                         self.seletedImageView.image = UIImage(data: imageData)
                         

--- a/Studing/Studing/Presentation/Login & Signup/ViewModel/TermsOfServiceViewModel.swift
+++ b/Studing/Studing/Presentation/Login & Signup/ViewModel/TermsOfServiceViewModel.swift
@@ -39,6 +39,7 @@ final class TermsOfServiceViewModel: BaseViewModel {
     // MARK: - Private properties
     
     private var cancellables = Set<AnyCancellable>()
+    weak var delegate: InputmarketingDelegate?
     
     // MARK: - Public methods
     
@@ -102,14 +103,16 @@ final class TermsOfServiceViewModel: BaseViewModel {
             isServiceBoxSubject,
             isUserInfoSubject
         )
-
+        
         let isNextButtonEnabled = nextButtonState
-            .map { allBox, serviceBox, userInfoBox in
-                allBox || (serviceBox && userInfoBox)
+            .map { [weak self] allBox, serviceBox, userInfoBox in
+                let isEnabled = allBox || (serviceBox && userInfoBox)
+                self?.delegate?.didSubmitMarketing(self?.isMarketingSubject.value ?? false)
+                return isEnabled
             }
             .eraseToAnyPublisher()
 
-       
+
         return Output(
             allCheckBoxTap: isAllCheckBoxSubject.eraseToAnyPublisher(),
             serviceBoxTap: isServiceBoxSubject.eraseToAnyPublisher(),

--- a/Studing/Studing/Studing.entitlements
+++ b/Studing/Studing/Studing.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>aps-environment</key>
+	<string>development</string>
+</dict>
+</plist>


### PR DESCRIPTION
## 📟 관련 이슈
- Resolved: #39

<br>

## 👷 작업한 내용
<!-- 작업한 내용을 적어주세요. -->
- Firebase 의 FCM 관련 세팅 구현
- KeyChain 에 FCM 저장 로직 구현
- 로그인 후 FCM 토큰을 서버에 저장하는 API 구현
- 회원가입 시 마케팅 유무 저장 로직 구현

<br>

## ✅ Checklist
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
