### PR TITLE
[Feat] #58 - 마이페이지 및 알람 설정 화면 UI 수정

### DIFF
--- a/Studing/Studing.xcodeproj/project.pbxproj
+++ b/Studing/Studing.xcodeproj/project.pbxproj
@@ -175,6 +175,7 @@
 		3F59602F2CA1422100688FE3 /* UIStackView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F59602E2CA1422100688FE3 /* UIStackView+.swift */; };
 		3F5D9E402D6A03170059EA3D /* AlarmSettingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F5D9E3F2D6A03170059EA3D /* AlarmSettingViewModel.swift */; };
 		3F5D9E422D6B24100059EA3D /* TestFlight.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 3F5D9E412D6B24100059EA3D /* TestFlight.xcconfig */; };
+		3F5D9E472D708C1B0059EA3D /* AlarmSettingState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F5D9E462D708C1B0059EA3D /* AlarmSettingState.swift */; };
 		3F5DEF812D5DB8A00016FE44 /* DateComponents+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F5DEF802D5DB8A00016FE44 /* DateComponents+.swift */; };
 		3F5DEF832D6324B40016FE44 /* SingleButtonConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F5DEF822D6324B40016FE44 /* SingleButtonConfiguration.swift */; };
 		3F5DEF852D65693A0016FE44 /* Decodable+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F5DEF842D65693A0016FE44 /* Decodable+.swift */; };
@@ -495,6 +496,7 @@
 		3F59602E2CA1422100688FE3 /* UIStackView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIStackView+.swift"; sourceTree = "<group>"; };
 		3F5D9E3F2D6A03170059EA3D /* AlarmSettingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlarmSettingViewModel.swift; sourceTree = "<group>"; };
 		3F5D9E412D6B24100059EA3D /* TestFlight.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = TestFlight.xcconfig; sourceTree = "<group>"; };
+		3F5D9E462D708C1B0059EA3D /* AlarmSettingState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlarmSettingState.swift; sourceTree = "<group>"; };
 		3F5DEF802D5DB8A00016FE44 /* DateComponents+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DateComponents+.swift"; sourceTree = "<group>"; };
 		3F5DEF822D6324B40016FE44 /* SingleButtonConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SingleButtonConfiguration.swift; sourceTree = "<group>"; };
 		3F5DEF842D65693A0016FE44 /* Decodable+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Decodable+.swift"; sourceTree = "<group>"; };
@@ -1541,6 +1543,7 @@
 			children = (
 				3FE0432D2CC6631100B55EAA /* MyPageType.swift */,
 				3FFF992B2D0ADA5F00EEBB70 /* MypageNavigationType.swift */,
+				3F5D9E462D708C1B0059EA3D /* AlarmSettingState.swift */,
 			);
 			path = Enum;
 			sourceTree = "<group>";
@@ -2097,6 +2100,7 @@
 				3FFF2E992D534B6C00C5FFC8 /* DeleteAlarmNoticeUseCase.swift in Sources */,
 				3F25A3622C96CF4C006E2715 /* Coordinator.swift in Sources */,
 				3FFF99312D0ADD4300EEBB70 /* SerachResultType.swift in Sources */,
+				3F5D9E472D708C1B0059EA3D /* AlarmSettingState.swift in Sources */,
 				3F3A69372CE85764006334C3 /* SuccessSignUpViewModel.swift in Sources */,
 				3F1739852CC01CAB00DE8859 /* HomeViewController.swift in Sources */,
 				3FFCFEF32CE0D822009D07A6 /* MemberAPI.swift in Sources */,

--- a/Studing/Studing/Global/Consts/FontLiterals.swift
+++ b/Studing/Studing/Global/Consts/FontLiterals.swift
@@ -89,8 +89,16 @@ extension UIFont {
         return  UIFont(name: FontName.InterRegualrMedium.rawValue, size: 14)!
     }
     
+    @nonobjc class func interSemiBoldBody14() -> UIFont {
+        return UIFont(name: FontName.InterRegualrSemiBold.rawValue, size: 14)!
+    }
+    
     @nonobjc class func interCaption16() -> UIFont {
         return UIFont(name: FontName.InterRegualr.rawValue, size: 16)!
+    }
+    
+    @nonobjc class func interSemiBoldCaption12() -> UIFont {
+        return UIFont(name: FontName.InterRegualrSemiBold.rawValue, size: 12)!
     }
     
     @nonobjc class func interCaption12() -> UIFont {

--- a/Studing/Studing/Presentation/TabBar/Mypage/AlarmSettingViewController.swift
+++ b/Studing/Studing/Presentation/TabBar/Mypage/AlarmSettingViewController.swift
@@ -101,7 +101,7 @@ private extension AlarmSettingViewController {
         output.viewLifeCycleEventResult
             .receive(on: DispatchQueue.main)
             .sink { [weak self] result in
-                self?.alarmInfomationView.isHidden = result
+                self?.alarmInfomationView.changeAlarmState(isAlarm: result)
             }
             .store(in: &cancellables)
         
@@ -126,17 +126,11 @@ private extension AlarmSettingViewController {
             $0.axis = .vertical
             $0.distribution = .fill
             $0.spacing = 0
-            $0.addArrangedSubviews(alarmInfomationView, announceAlarmSettingView)
+            $0.addArrangedSubviews(alarmInfomationView)
         }
         
-        alarmInfomationView.do {
-            $0.isUserInteractionEnabled = true
-            $0.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(alarmInfomationViewTappend)))
-        }
-        
-        announceAlarmSettingView.do {
-            $0.isUserInteractionEnabled = true
-            $0.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(alarmInfomationViewTappend)))
+        alarmInfomationView.setAlarmSettingAction { [weak self] in
+            self?.osSettingSubject.send()
         }
     }
     
@@ -149,10 +143,6 @@ private extension AlarmSettingViewController {
             $0.top.equalTo(view.safeAreaLayoutGuide.snp.top)
             $0.horizontalEdges.equalToSuperview().inset(15)
             $0.bottom.equalToSuperview()
-        }
-        
-        alarmInfomationView.snp.makeConstraints {
-            $0.height.equalTo(94)
         }
     }
     

--- a/Studing/Studing/Presentation/TabBar/Mypage/Enum/AlarmSettingState.swift
+++ b/Studing/Studing/Presentation/TabBar/Mypage/Enum/AlarmSettingState.swift
@@ -1,0 +1,58 @@
+//
+//  AlarmSettingState.swift
+//  Studing
+//
+//  Created by ParkJunHyuk on 2/27/25.
+//
+
+import UIKit
+
+enum AlarmSettingState {
+    case alarmOn
+    case alamrOff
+    
+    var title: String {
+        switch self {
+        case .alamrOff:
+            return "알림 켜기"
+        case .alarmOn:
+            return "알림 끄기"
+        }
+    }
+    
+    var backgroundColor: UIColor {
+        switch self {
+        case .alamrOff:
+            return .primary50
+        case .alarmOn:
+            return .primary20
+        }
+    }
+    
+    var fontColor: UIColor {
+        switch self {
+        case .alamrOff:
+            return .white
+        case .alarmOn:
+            return .primary40
+        }
+    }
+    
+    var mainTitle: String {
+        switch self {
+        case .alamrOff:
+            return "알림을 켜주세요"
+        case .alarmOn:
+            return "알림이 켜져있어요"
+        }
+    }
+    
+    var subTitle: String {
+        switch self {
+        case .alamrOff:
+            return "새로운 공지와 이벤트 소식을 받아보세요"
+        case .alarmOn:
+            return "새로운 공지와 이벤트 소식을 받고 있어요"
+        }
+    }
+}

--- a/Studing/Studing/Presentation/TabBar/Mypage/Enum/MyPageType.swift
+++ b/Studing/Studing/Presentation/TabBar/Mypage/Enum/MyPageType.swift
@@ -41,7 +41,7 @@ enum MyPageType: CaseIterable {
     var title: String {
         switch self {
         case .myInfo: return ""
-        case .useInfo: return "이용 안내"
+        case .useInfo: return "이용안내"
         case .etc: return "기타"
         }
     }
@@ -52,7 +52,7 @@ enum MyPageType: CaseIterable {
     var items: [String] {
         switch self {
         case .myInfo: return [""]
-        case .useInfo: return ["앱 버전", "문의하기", "서비스 이용안내", "개인정보 처리방침", "알림 설정"]
+        case .useInfo: return ["알림 설정", "문의하기", "서비스 이용안내", "개인정보 처리방침", "앱 버전"]
         case .etc: return ["로그아웃", "회원탈퇴"]
         }
     }

--- a/Studing/Studing/Presentation/TabBar/Mypage/MypageViewController.swift
+++ b/Studing/Studing/Presentation/TabBar/Mypage/MypageViewController.swift
@@ -136,7 +136,7 @@ private extension MypageViewController {
         collectionView.snp.makeConstraints {
             $0.top.equalTo(view.safeAreaLayoutGuide.snp.top)
             $0.horizontalEdges.equalToSuperview()
-            $0.bottom.equalTo(view.safeAreaLayoutGuide.snp.bottom).inset(15)
+            $0.bottom.equalTo(view.safeAreaLayoutGuide.snp.bottom).inset(10)
         }
     }
     

--- a/Studing/Studing/Presentation/TabBar/Mypage/View/AlarmInfomationView.swift
+++ b/Studing/Studing/Presentation/TabBar/Mypage/View/AlarmInfomationView.swift
@@ -12,59 +12,95 @@ import Then
 
 final class AlarmInfomationView: UIView {
     
+    // MARK: - Properties
+    
+    private var alarmButtonAction: (() -> Void)?
+    private var alarmState: AlarmSettingState?
+    
     // MARK: - UI Properties
     
     private let backgroundView = UIView()
     private let titleLabel = UILabel()
     private let subTitleLabel = UILabel()
-    private let arrowImageView = UIImageView()
+    private let alarmSettingButton = UIButton()
     
     // MARK: - Init
     
     init() {
         super.init(frame: .zero)
-        
-        setupStyle()
-        setupHierarchy()
-        setupLayout()
     }
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+    
+    func changeAlarmState(isAlarm: Bool) {
+        alarmState = isAlarm ? .alarmOn : .alamrOff
+        
+        updateLayout()
+    }
+    
+    func updateLayout() {
+        guard let alarmState else { return }
+        
+        setupStyle(state: alarmState)
+        setupHierarchy()
+        setupLayout()
+    }
+    
+    func setAlarmSettingAction(_ action: @escaping () -> Void) {
+        self.alarmButtonAction = action
+        
+        // 기존에 설정된 Target을 제거한 후, 새로운 Target 추가 (중복 방지)
+        alarmSettingButton.removeTarget(self, action: #selector(buttonTapped), for: .touchUpInside)
+        alarmSettingButton.addTarget(self, action: #selector(buttonTapped), for: .touchUpInside)
+    }
+    
+    @objc private func buttonTapped() {
+        alarmButtonAction?()
     }
 }
 
 // MARK: - Private Extensions
 
 private extension AlarmInfomationView {
-    func setupStyle() {
+    func setupStyle(state: AlarmSettingState) {
         backgroundView.do {
             $0.backgroundColor = .primary10
             $0.layer.cornerRadius = 20
+            $0.layer.borderWidth = 0.7
+            $0.layer.borderColor = UIColor.primary20.cgColor
         }
         
         titleLabel.do {
-            $0.text = "알림을 켜주세요"
+            $0.text = state.mainTitle
             $0.textColor = .primary50
             $0.font = .interSubtitle3()
         }
         
         subTitleLabel.do {
-            $0.text = "OS 알림이 꺼져 있으면, 알림을 받을 수 없어요.\nOS 설정에서 알림을 켜주세요."
+            $0.text = state.subTitle
             $0.textColor = .primary40
             $0.font = .interCaption12()
             $0.numberOfLines = 0
         }
         
-        arrowImageView.do {
-            $0.image = UIImage(systemName: "chevron.right")
-            $0.tintColor = .primary50
+        alarmSettingButton.do {
+            $0.backgroundColor = state.backgroundColor
+            $0.layer.cornerRadius = 16
+            
+            let attributedString = NSAttributedString(string: state.title, attributes: [
+                .font: UIFont.interSemiBoldCaption12(),
+                .foregroundColor: state.fontColor
+            ])
+            
+            alarmSettingButton.setAttributedTitle(attributedString, for: .normal)
         }
     }
     
     func setupHierarchy() {
         self.addSubview(backgroundView)
-        backgroundView.addSubviews(titleLabel, subTitleLabel, arrowImageView)
+        backgroundView.addSubviews(titleLabel, subTitleLabel, alarmSettingButton)
     }
     
     func setupLayout() {
@@ -74,20 +110,22 @@ private extension AlarmInfomationView {
         }
         
         titleLabel.snp.makeConstraints {
-            $0.top.equalToSuperview().offset(14)
+            $0.top.equalToSuperview().offset(21.5)
             $0.leading.equalToSuperview().offset(20)
         }
         
         subTitleLabel.snp.makeConstraints {
             $0.top.equalTo(titleLabel.snp.bottom).offset(8)
             $0.leading.equalToSuperview().inset(20)
-            $0.trailing.equalTo(arrowImageView.snp.leading)
-            $0.bottom.equalToSuperview().inset(14)
+            $0.trailing.equalTo(alarmSettingButton.snp.leading)
+            $0.bottom.equalToSuperview().inset(21.5)
         }
         
-        arrowImageView.snp.makeConstraints {
-            $0.verticalEdges.equalToSuperview().inset(32)
+        alarmSettingButton.snp.makeConstraints {
+            $0.verticalEdges.equalToSuperview().inset(26)
             $0.trailing.equalToSuperview().inset(20)
+            $0.width.equalTo(69)
+            $0.height.equalTo(32)
         }
     }
 }

--- a/Studing/Studing/Presentation/TabBar/Mypage/ViewModel/MypageViewModel.swift
+++ b/Studing/Studing/Presentation/TabBar/Mypage/ViewModel/MypageViewModel.swift
@@ -98,7 +98,10 @@ final class MypageViewModel: BaseViewModel {
         switch section {
         case .useInfo:
             switch index {
-            case 1: 
+            case 0:
+                navigationEventSubject.send(.alarmSetting)
+                
+            case 1:
                 navigationEventSubject.send(.notice)
                 AmplitudeManager.shared.trackEvent(AnalyticsEvent.MyPage.contact)
                 
@@ -107,9 +110,6 @@ final class MypageViewModel: BaseViewModel {
                 
             case 3:
                 navigationEventSubject.send(.privacyPolicy)
-                
-            case 4:
-                navigationEventSubject.send(.alarmSetting)
                 
             default: break
             }


### PR DESCRIPTION
## 📟 관련 이슈
- Resolved: #58 

<br>

## 👷 작업한 내용
<!-- 작업한 내용을 적어주세요. -->
- 알림 화면 UI 및 로직 수정
- SemiBold 관련 폰트 추가
- 마이페이지의 이용안내 섹션의 순서 변경

<br>

## 📸 스크린샷
|기능|마이페이지 화면|알림 설정 화면(꺼짐)|알림 설정 화면(켜짐)|
|:--:|:--:|:--:|:--:|
|GIF|<img src = "https://github.com/user-attachments/assets/d9bce42a-81fd-4642-9795-4fbd3005feda" width ="250">|<img src = "https://github.com/user-attachments/assets/610da221-ed54-49c9-8236-81f9432bba21" width ="250">|<img src = "https://github.com/user-attachments/assets/31ace832-7353-4c84-9dc5-5164a536be6e" width ="250">|

<br>

## 🚨 참고 사항
<!-- 참고 사항을 적어주세요. 없으면 지워주세요. -->

### 1. 알림 설정 로직

위의 알림 설정 화면은 새로운 공지와 이벤트 소식에 대한 알람을 키고 끌 수 있는 화면입니다.
다만 앱 내부에서 알림을 키고 끄는 것이 아닌 앱 시스템의 알림 동작에 관한 화면으로 넘어가게 됩니다.

단순히 지금은 공지사항에 대한 알림밖에 존재하지 않기 때문에 다음과 같이 진행했습니다.
만약 앞으로 알림 설정에 관한 경우의 수가 늘어난다면 앱 내부에서 알림을 키고 끌 수 있게 FCM 토큰을 제거하는 방식으로 변경하도록 방안을 마련하고 있습니다.

<br>

## ✅ Checklist
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
